### PR TITLE
Wiederherstellung der Anzeige der durchschnittlichen Leistung

### DIFF
--- a/data/cust.js
+++ b/data/cust.js
@@ -212,7 +212,15 @@ function updateElements(obj) {
       else         $("#tdy_diff").css({'color':'#0000FF'});
       $("#tdy_diff").html(toNumberString(diff / 1000, 3));
       setAvgItem("tdy_diff", diff, secsDayStart, true);
-
+      
+      if (diff >0) $("#perhour_tdy").css({'color':'#FF0000'});
+      else         $("#perhour_tdy").css({'color':'#0000FF'});
+      if (secsDayStart > 0) {
+        $("#perhour_tdy").html(toNumberString((diff * 3600) / secsDayStart / 1000, 3));
+      } else {
+        $("#perhour_tdy").html(toNumberString(diff / 1000, 3));
+      }
+      
       for (let i=0;i<7;i++ ) {
         let datax = "data" + i;
         let date = adjustDays(g_lastDT, -1 - i);
@@ -230,6 +238,10 @@ function updateElements(obj) {
           else         $("#wd_diff"+i).css({'color':'#0000FF'});
           $("#wd_diff"+i).html(toNumberString(diff / 1000, 3));
           setAvgItem("wd_diff"+i, diff, secsDay, true);
+          
+          if (diff >0) $("#perhour_"+i).css({'color':'#FF0000'});
+          else         $("#perhour_"+i).css({'color':'#0000FF'});
+          $("#perhour_"+i).html(toNumberString((diff * 3600) / secsDay / 1000, 3));
         }
       }
       continue;


### PR DESCRIPTION
Wie in #11 festgestellt, funktioniert die Anzeige der durchschnittlichen Leistung nicht mehr, weil es einen Schiefstand bei den Git Sources gegeben hat, und der Code dafür nicht im Repository vorhanden war. Nach Download des Sources von (http://www.mitterbaur.at/amis/firmware1-3-1.zip) und Vergleich mit dem Source von Github ist hier nun der PR, der die Github Sources wieder auf Stand bringen sollte.

Es hat lediglich die Funktion für die Anzeige der durchschnittlichen Leistung gefehlt, der Rest passt zusammen.

Bitte die cust.js in den Reader reinladen und Browser Cache leeren, danach sollte es so aussehen:

![grafik](https://github.com/user-attachments/assets/d0575f6a-1a7c-4bd0-bb60-0955cbf7c453)
