### PR TITLE
1.6.1 minimize log

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -845,6 +845,10 @@
           <br>
           <div class="pure-g hist">
             <div class="pure-u-1">
+              <h3>Version 1.6.1</h3>
+              Logging verringert:<br>
+              - Uhrzeitsyncronisation wird nur geloggt, wenn Differenz größer als eine Sekunde.<br>
+              - MQTT, ThingSpeak und WiFi: Es werden nur 2 Fehlversuche im Log protokolliert.<br>
               <h3>Version 1.6.0</h3>
               Fix von <a href="https://github.com/mgerhard74/amis_smartmeter_reader/issues/57">Issue #57</a>: MQTT Connection unstable since 1.5.9<br>
               Failsafe-Mode: Wenn der Leser innerhalb von 90 Sekunden 5 Mal rebootet wird er in den Failsafe-Mode gebracht.<br>

--- a/include/ProjectConfiguration.h
+++ b/include/ProjectConfiguration.h
@@ -2,7 +2,7 @@
 
 // Eckdaten der Applikation
 #define APP_NAME        "Amis"
-#define APP_VERSION_STR "1.6.0"
+#define APP_VERSION_STR "1.6.1"
 
 
 // Pin, mit dem der Zähler mittels Jumper auf Masse

--- a/src/AmisReader.cpp
+++ b/src/AmisReader.cpp
@@ -113,7 +113,10 @@ static void setTime(time_t ts_now) {
     ti.tv_usec = 105000;
     settimeofday(&ti, NULL);
 
-    LOGF_IP("Time synchronized. (ts-old=%llu, ts-now=%llu, millis=%u)", tv_sec_old, ts_now, millis());
+    if (tv_sec_old - ts_now > 1 || tv_sec_old - ts_now < -1) {
+        // only log if time diff is more than 1 sec
+        LOGF_IP("Time sync (counter). (ts-old=%llu, ts-now=%llu, millis=%u)", tv_sec_old, ts_now, millis());
+    }
     RebootAtMidnight.adjustTicker();
 }
 

--- a/src/MqttBaseClass.inl
+++ b/src/MqttBaseClass.inl
@@ -3,7 +3,7 @@
 //    *  MqttHAClass            handling
 //    *  MqttReaderDataClass
 
-#define MQTT_LOG_MAX_CONNECTION_ATTEMPS         3
+#define MQTT_LOG_MAX_CONNECTION_ATTEMPS         2
 
 void MqttBaseClass::init()
 {

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -21,7 +21,7 @@
 
 extern const char *__COMPILED_GIT_HASH__;
 
-#define NETWORK_LOG_MAX_CONNECTION_ATTEMPS   3
+#define NETWORK_LOG_MAX_CONNECTION_ATTEMPS   2
 
 void NetworkClass::init(bool apMode)
 {

--- a/src/ThingSpeak.cpp
+++ b/src/ThingSpeak.cpp
@@ -5,7 +5,7 @@
 #include "Network.h"
 #include "Utils.h"
 
-#define THINGSPEAK_LOG_MAX_CONNECTION_ATTEMPS   3
+#define THINGSPEAK_LOG_MAX_CONNECTION_ATTEMPS   2
 
 void ThingSpeakClass::init()
 {


### PR DESCRIPTION
Logging verringert:

- Uhrzeitsyncronisation wird nur geloggt, wenn Differenz größer als eine Sekunde.
- MQTT, ThingSpeak und WiFi: Es werden nur mehr 2 Fehlversuche im Log protokolliert.