### PR TITLE
Shelly Emulation: RPC over HTTP und mDNS Ankündigung (Issue #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Der NetzOÖ Smartmeter gibt Daten im Sekundentakt aus, somit stehen jede Sekunde
 Der Amis Leser benötigt eine 5V Spannungsversorgung (max. 0,13A, typ. 0,075A; Leistungsaufnahme < 1W) durch ein Micro-USB Netzteil und wird magnetisch durch 3 Magnete, die an der Platinenunterseite angeklebt sind, an der optischen Kundenschnittstelle des Siemens Smartmeter gehalten.
 
 Der AMIS Leser emuliert auch einen Fronius Smartmeter (nur Einspeisepunkt Adresse 1) per Modbus/TCP für einen Fronius Symo (ab Datamanager Version 3.28.1-3) oder Gen24 Wechselrichter. Siehe dazu Docs/AmisFroniusSmartmeter.pdf.
+Ebenso kann ein Shelly Smartmeter (Pro 3EM, Pro EM-50, EM Gen3) emuliert werden, wie ihn viele Balkonkraftwerksspeicher für die Nulleinspeisung erwarten. Dafür stehen zwei Varianten zur Verfügung, die auch gemeinsam aktiv sein können:
+- "RPC over UDP" für Speicher vom Typ B2500 (z.B. Marstek Saturn), die den Shelly per UDP-Broadcast abfragen.
+- "RPC over HTTP" für Speicher, die den Shelly per mDNS im Netzwerk suchen und danach per HTTP abfragen (z.B. Solakon One, Hoymiles, Anker). Der Leser meldet sich dabei als `_http._tcp`/`_shelly._tcp` an und beantwortet unter seiner normalen Webserver-Adresse zusätzlich `/shelly` sowie `/rpc/<Methode>` (`EM.GetStatus`, `EMData.GetStatus`, `EM.GetConfig`, `Shelly.GetDeviceInfo`, `Shelly.ListMethods`, bzw. die `EM1.*` Varianten bei einphasigen Geräten).
+  Findet ein Speicher den Leser nicht, kann optional der Shelly-Name (z.B. `ShellyPro3EM-8C4F0044B70B.local`) als mDNS-Hostname verwendet werden - für Geräte, die diesen Namen direkt auflösen statt dem SRV-Eintrag zu folgen. `<Gerätename>.local` ist dann nicht mehr auflösbar, da der ESP8266 nur einen mDNS-Hostnamen führen kann.
+
 In der aktuellen Version ist es auch möglich eine (Tasmota-, Shelly-)Wifi Steckdose aufgrund von PV Überschuss anzusteuern. ("Ein" unter Saldowert; "Aus" über Saldowert; Url für Ein bzw Aus)
 
 Startseite Webinterface:
@@ -18,7 +23,7 @@ Startseite Webinterface:
 ## Highlights
 - Webinterface (Einstellungen, Updates)
 - Schnittstellen: RestApi, MQTT, ModbusTCP, Upload zu Thingspeak
-- Wifi Sleep Mode, Neustart bei Ping-Fehler, Schaltet eine Tasmota Steckdose bei PV Überschuss, Emuliert einen Fronuis Smartmeter per ModbusTCP
+- Wifi Sleep Mode, Neustart bei Ping-Fehler, Schaltet eine Tasmota Steckdose bei PV Überschuss, Emuliert einen Fronuis Smartmeter per ModbusTCP, Emuliert einen Shelly Smartmeter per UDP und HTTP
 
 ## Inbetriebnahme
 Der Amis-ESP8266 läuft normalerweise im Station-Mode, d.h. der ESP8266 verbindet sich als Client mit einem Wlan Router/AP. Dazu muss er aber erst einmal die SSID und das Wlan Passwort kennen. Daher wird der ESP8266 zur Einrichtung in den AP-Mode (Access-Point) versetzt. Das geschieht, indem man mit gesetztem Jumper (Steckbrücke) bootet.

--- a/data/cust.js
+++ b/data/cust.js
@@ -36,6 +36,8 @@ var config_general = {
     "rest_neg": false,
     "smart_mtr":false,
     "shelly_smart_mtr_udp": false,
+    "shelly_smart_mtr_http": false,
+    "shelly_smart_mtr_http_hostname": false,
     "shelly_smart_mtr_udp_device_index": 0,
     "shelly_smart_mtr_udp_offset": 0,
     "shelly_smart_mtr_udp_hardware_id_appendix": "",

--- a/data/index.html
+++ b/data/index.html
@@ -620,10 +620,35 @@
         </div>
         <hr><br>
         <div class="pure-g">
-          <label class="pure-u-2-3">Shelly Smartmeter Emulation aktiv:</label>
+          <label class="pure-u-2-3">Shelly Smartmeter Emulation (UDP) aktiv:</label>
           <div class="pure-u-1-3 "><input type="checkbox" name="shelly_smart_mtr_udp" id="shelly_smart_mtr_udp" class="general"/></div>
           <div class="pure-u-1 hint">
             Eine Shelly Smartmeter Emulation auf Basis "RPC over UDP" wird aktiviert (nicht die Rest-Schnittstelle). Balkonspeicher vom Type B2500 (z.B. Marstek Saturn...) verwenden diese Methode für die Nulleinspeisung.
+          </div>
+        </div>
+        <div class="pure-g">
+          <label class="pure-u-2-3">Shelly Smartmeter Emulation (HTTP) aktiv:</label>
+          <div class="pure-u-1-3 "><input type="checkbox" name="shelly_smart_mtr_http" id="shelly_smart_mtr_http" class="general"/></div>
+          <div class="pure-u-1 hint">
+            Eine Shelly Smartmeter Emulation auf Basis "RPC over HTTP" wird aktiviert: Der Reader beantwortet unter seiner normalen Webserver-Adresse zusätzlich
+            <code>/shelly</code> sowie <code>/rpc/&lt;Methode&gt;</code> (z.B. <code>/rpc/EM.GetStatus</code>) und meldet sich per mDNS als Shelly im Netzwerk an.
+            Das brauchen Speicher, die den Shelly selbst im Netzwerk suchen und dann per HTTP abfragen (z.B. Solakon One, Hoymiles, Anker).
+            <br>
+            Hinweis: Dafür wird der mDNS-Responder benötigt und daher automatisch gestartet, auch wenn mDNS in den WLAN-Einstellungen deaktiviert ist.
+          </div>
+        </div>
+        <div class="pure-g">
+          <label class="pure-u-2-3">&nbsp;&nbsp;&rarr; Shelly-Namen als mDNS-Hostnamen verwenden:</label>
+          <div class="pure-u-1-3 "><input type="checkbox" name="shelly_smart_mtr_http_hostname" id="shelly_smart_mtr_http_hostname" class="general"/></div>
+          <div class="pure-u-1 hint">
+            Nur wirksam, wenn die HTTP Emulation aktiv ist.
+            Manche Speicher lösen den Shelly-Namen direkt auf, statt dem angekündigten Diensteintrag zu folgen. Dafür meldet sich der Reader dann unter
+            <code>&lt;Shelly-Name&gt;.local</code> (z.B. <code>ShellyPro3EM-8C4F0044B70B.local</code>) &mdash; <code>&lt;Gerätename&gt;.local</code> ist dann nicht mehr auflösbar,
+            weil der ESP8266 nur einen einzigen mDNS-Hostnamen führen kann. Über die IP-Adresse ist der Reader in beiden Fällen wie gewohnt erreichbar,
+            und als Dienst wird er weiterhin unter dem Gerätenamen angekündigt.
+            <br>
+            Normalerweise nicht nötig: Der angekündigte Diensteintrag verweist auf <code>&lt;Gerätename&gt;.local</code>, und das ist auflösbar.
+            Nur einschalten, wenn der Speicher den Reader sonst nicht findet.
           </div>
         </div>
         <div class="pure-g">
@@ -637,6 +662,7 @@
           <div class="pure-u-1 hint">
             Es gibt mehrere Shelly's die ähnlich arbeiten und emuliert werden können. Bei Verwendung von Shelly Pro 3EM: Ist die Firmware der Batterie <= 224, den entsprechenden Eintrag wählen.
             Der in den Klammern angegebene UDP Port muss per UDP Broadcast im Netzwerk/Router weitergeleitet werden können.
+            Die Auswahl gilt für beide Emulationen (UDP und HTTP), bei HTTP legt sie fest, als welches Gerät sich der Reader im Netzwerk meldet.
             <br>
           </div>
         </div>
@@ -652,7 +678,7 @@
             <label class="pure-u-1-2">Shelly Hardware ID (optional)</label>
             <input class="pure-u-1-2 general" name="shelly_smart_mtr_udp_hardware_id_appendix" type="text" id="shelly_smart_mtr_udp_hardware_id_appendix" maxlength="16"/>
             <div class="pure-u-1 pure-u-sm-2-5 hint">
-                Wenn nicht definiert, wird automatisch eine ID auf Basis der ESP-ID generiert.
+                Wenn nicht definiert, wird - so wie beim Originalgerät - automatisch eine ID auf Basis der MAC-Adresse generiert.
             </div>
         </div>
         <div class="pure-g">
@@ -847,6 +873,7 @@
             <div class="pure-u-1">
               <h3>Version 1.6.2</h3>
               Fix für Internetausfall in Verbindung mit aktivem Thingspeak Upload <a href="https://github.com/mgerhard74/amis_smartmeter_reader/issues/64">Issue #64</a><br>
+              Shelly Emulation auch per HTTP inkl. Ankündigung per mDNS (<code>/shelly</code>, <code>/rpc/&lt;Methode&gt;</code>) für Speicher, die den Shelly selbst im Netzwerk suchen (z.B. Solakon One, Hoymiles, Anker) <a href="https://github.com/mgerhard74/amis_smartmeter_reader/issues/36">Issue #36</a><br>
               <h3>Version 1.6.1</h3>
               Logging verringert:<br>
               - Uhrzeitsyncronisation wird nur geloggt, wenn Differenz größer als eine Sekunde.<br>

--- a/include/ShellySmartmeterEmulation.h
+++ b/include/ShellySmartmeterEmulation.h
@@ -3,7 +3,12 @@
 
 #include <map>
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include <ESPAsyncUDP.h>
+
+// Capacity of a json document which is big enough to hold the "result" object
+// of every RPC method supported by buildRpcResult() (biggest one: "EM.GetStatus").
+#define SHELLY_RPC_RESULT_JSON_CAPACITY     (JSON_OBJECT_SIZE(25) + JSON_ARRAY_SIZE(0) + 288)
 
 class ShellySmartmeterEmulationClass {
 public:
@@ -12,28 +17,74 @@ public:
     bool init(unsigned selectedDeviceIndex, const char *customDeviceIDAppendix, int saldoOffset);
     bool setEnabled(bool enabled);
     bool enable();
+    //NOTE: disables the UDP *and* the HTTP API (used by RebootClass to stop the emulation completely)
     void disable();
-    //NOTE: kept signature of function to match ModbusSmartmeterEmulation (actually 1.8.0 & 2.8.0 not needed)
+    //NOTE: kept signature of function to match ModbusSmartmeterEmulation
     void setCurrentValues(bool dataAreValid, uint32_t v1_7_0=0, uint32_t v2_7_0=0, uint32_t v1_8_0=0, uint32_t v2_8_0=0);
+
+    // "RPC over HTTP" (see Webserver_Shelly.cpp) and the mDNS announcement (see Network.cpp).
+    // There is no socket to open/close - the requests are served by our regular webserver -
+    // so enabling/disabling is just a flag.
+    bool enableHttpApi();
+    void disableHttpApi();
+    bool httpApiEnabled() const { return _httpApiEnabled; }
+
+    bool isInitialized() const { return _device.id[0] != '\0'; }
+    bool hasValidData() const { return _currentValues.dataAreValid; }
+
+    // Device properties needed by the HTTP API and by the mDNS announcement.
+    // NOTE: The strings live in PROGMEM, so they are returned as __FlashStringHelper.
+    //       ArduinoJson takes them as they are, everywhere else use String(...).
+    const char *getDeviceId() const { return _device.id; }              // eg "shellypro3em-a8032abe1234"
+    const char *getDeviceName() const { return _device.name; }          // eg "ShellyPro3EM-A8032ABE1234"
+    const __FlashStringHelper *getApp() const;                          // eg "Pro3EM" (Shelly.GetDeviceInfo)
+    const __FlashStringHelper *getMdnsApp() const;                      // eg "shellypro3em" (mDNS TXT record)
+    const __FlashStringHelper *getModel() const;                        // eg "SPEM-003CEBEU"
+    unsigned getGeneration() const;                                     // Shelly device generation
+    unsigned getMdnsGeneration() const;                                 // generation announced via mDNS
+    bool isTriphase() const;                                            // true: EM.* methods, false: EM1.* methods
+    static const __FlashStringHelper *getFirmwareId();
+    static const __FlashStringHelper *getFirmwareVersion();
+    // Mac address of our device as a Shelly reports it: uppercase hex, no separators
+    static String getMacAddress();
+
+    // Builds the "result" object of a Shelly RPC method into 'result'.
+    // With 'minimalResponse' only the values needed by the B2500 batteries are set
+    // (see handleRequest() why we do not want to change the UDP responses).
+    // Returns false if the method is not supported or if no valid meter data is available.
+    bool buildRpcResult(const char *method, JsonObject result, bool minimalResponse = false);
 
 private:
     typedef struct {
         uint16_t port;
-        char id[27];
+        char name[14 + 16 + 1]; // longest prefix ("ShellyProEM50-") + longest appendix + '\0'
+        char id[14 + 16 + 1];   // lowercase variant of 'name'
     } _device_t;
     _device_t _device;
+    unsigned _deviceIndex = 0;
 
     AsyncUDP _udp;
     bool _enabled = false;
+    bool _httpApiEnabled = false;
 
     struct {
         bool dataAreValid = false;
         int32_t saldo=0;
+        uint32_t v1_8_0=0, v2_8_0=0;
     } _currentValues;
     int _offset; // Watt offset for saldo
 
     bool listen();
     void handleRequest(AsyncUDPPacket udpPacket);
+
+    int32_t saldo() const { return _currentValues.saldo + _offset; }
+    void buildEmGetStatus(JsonObject result, bool minimalResponse);
+    void buildEm1GetStatus(JsonObject result, bool minimalResponse);
+    void buildEmDataGetStatus(JsonObject result);
+    void buildEm1DataGetStatus(JsonObject result);
+    void buildEmGetConfig(JsonObject result);
+    void buildDeviceInfo(JsonObject result);
+    void buildListMethods(JsonObject result);
 };
 
 

--- a/include/Webserver.h
+++ b/include/Webserver.h
@@ -2,6 +2,7 @@
 
 #include "Webserver_Login.h"
 #include "Webserver_Rest.h"
+#include "Webserver_Shelly.h"
 #include "Webserver_Update.h"
 #include "Webserver_ws_Console.h"
 #include "Webserver_ws_Data.h"
@@ -26,6 +27,7 @@ class WebserverClass
 
         WebserverLoginClass _websrvLogin;
         WebserverRestClass _websrvRest;
+        WebserverShellyClass _websrvShelly;
         WebserverUpdateClass _websrvUpdate;
 
         WebserverWsConsoleClass _websrvWsConsole;

--- a/include/Webserver_Shelly.h
+++ b/include/Webserver_Shelly.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <ESPAsyncWebServer.h>
+
+class WebserverShellyClass
+{
+    public:
+        void init(AsyncWebServer& server);
+
+    private:
+        void onShellyRequest(AsyncWebServerRequest* request);
+        void onRpcGetRequest(AsyncWebServerRequest* request);
+        void onRpcPostRequest(AsyncWebServerRequest* request);
+        void onRpcPostBody(AsyncWebServerRequest* request, uint8_t *data, size_t len, size_t index, size_t total);
+
+        bool sendRpcResult(AsyncWebServerRequest* request, const char *method);
+        void sendRpcError(AsyncWebServerRequest* request, int code, const char *method);
+};
+
+/* vim:set ts=4 et: */

--- a/include/config.h
+++ b/include/config.h
@@ -29,7 +29,7 @@
 #define CONFIG_AUTH_USERNAME_MAXLEN     32
 #define CONFIG_AUTH_PASSWORD_MAXLEN     32
 
-#define CONFIG_JSON_CONFIG_GENERAL_DOCUMENT_SIZE    JSON_OBJECT_SIZE(33) + 1024
+#define CONFIG_JSON_CONFIG_GENERAL_DOCUMENT_SIZE    JSON_OBJECT_SIZE(35) + 1024
 
 
 extern const char* Config_restValueKeys[2][9];
@@ -50,6 +50,8 @@ public:
     bool smart_mtr;
 
     bool shelly_smart_mtr_udp;
+    bool shelly_smart_mtr_http;
+    bool shelly_smart_mtr_http_hostname;
     unsigned shelly_smart_mtr_udp_device_index;
     int shelly_smart_mtr_udp_offset;
     char shelly_smart_mtr_udp_hardware_id_appendix[17];

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -12,7 +12,9 @@
 #include "Json.h"
 #include "ModbusSmartmeterEmulation.h"
 #include "Mqtt.h"
+#include "ShellySmartmeterEmulation.h"
 #include "SystemMonitor.h"
+#include "Webserver.h"
 
 #include <EEPROM.h>
 #include <ESP8266mDNS.h>
@@ -377,18 +379,52 @@ bool NetworkClass::loadConfigWifiFromEEPROM(NetworkConfigWifi_t &config)
 }
 
 
+/*
+    Announces the emulated Shelly as the real device does: an instance named after the
+    Shelly device name (eg "ShellyPro3EM-A8032ABE1234") with the TXT records the consumers
+    look at. Both "_http._tcp" and "_shelly._tcp" are needed, that's what a Shelly Gen2+ offers.
+
+    The SRV record points to the Shelly device name, which restartMDNSIfNeeded() uses as
+    the mDNS hostname while the emulation is active - just like the original device does.
+*/
+static void addShellyMDNSService(const char *service)
+{
+    // The instance name uses the "official" mixed case spelling - a Solakon One is
+    // picky about that, see https://github.com/mgerhard74/amis_smartmeter_reader/issues/36
+    MDNSResponder::hMDNSService hService = MDNS.addService(ShellySmartmeterEmulation.getDeviceName(),
+                                                          service, "tcp", WEBSERVER_HTTP_PORT);
+    if (!hService) {
+        LOGF_EP("Error adding MDNS service '%s' for the Shelly emulation!", service);
+        return;
+    }
+
+    MDNS.addServiceTxt(hService, "id", ShellySmartmeterEmulation.getDeviceId());
+    MDNS.addServiceTxt(hService, "mac", WiFi.macAddress().c_str()); // uppercase, with colons
+    MDNS.addServiceTxt(hService, "app", String(ShellySmartmeterEmulation.getMdnsApp()).c_str());
+    MDNS.addServiceTxt(hService, "model", String(ShellySmartmeterEmulation.getModel()).c_str());
+    MDNS.addServiceTxt(hService, "gen", String(ShellySmartmeterEmulation.getMdnsGeneration()).c_str());
+    MDNS.addServiceTxt(hService, "ver", String(ShellySmartmeterEmulation.getFirmwareVersion()).c_str());
+    MDNS.addServiceTxt(hService, "fw_id", String(ShellySmartmeterEmulation.getFirmwareId()).c_str());
+    // The emulated devices are esp32 based - report what the original does, not what we are
+    MDNS.addServiceTxt(hService, "arch", "esp32");
+}
+
 void NetworkClass::restartMDNSIfNeeded()
 {
     if (Network.inAPMode()) {
         return;
     }
 
+    // The Shelly emulation is only discoverable with a running MDNS responder,
+    // so we start it even if the user did not enable MDNS himself.
+    bool doMDNS = _configWifi.mdns || ShellySmartmeterEmulation.httpApiEnabled();
+
     // Totally strange:
     //   MDNS.isRunning() returns true even if we called MSND.end() previously ... check this
     // So stop ... and if needed start
     bool isRunning = MDNS.isRunning();
     bool doRestart = false;
-    if (isRunning && _configWifi.mdns && _isConnected) {
+    if (isRunning && doMDNS && _isConnected) {
         doRestart = true;
     } else {
         doRestart = false;
@@ -398,18 +434,34 @@ void NetworkClass::restartMDNSIfNeeded()
 
     MDNS.end();
 
-    if (_configWifi.mdns && _isConnected) {
+    if (doMDNS && _isConnected) {
         LOGF_IP("(Re)starting MDNS responder.");
 
+        // A real Shelly answers to "<shelly device name>.local". Consumers normally follow
+        // the SRV record of the announced service (which points to us and resolves fine),
+        // but should one resolve the Shelly name directly, we can take it over as our
+        // mDNS hostname. Off by default - a Solakon One does not need it.
+        // Our own services keep the configured device name as their instance name, so the
+        // reader itself stays discoverable ... but "<devicename>.local" does not resolve then.
+        // (The mDNS responder of the ESP8266 only knows a single hostname, so it is one or
+        //  the other - see MDNSResponder::m_pcHostname.)
+        const char *hostname = Config.DeviceName;
+        if (ShellySmartmeterEmulation.httpApiEnabled() && Config.shelly_smart_mtr_http_hostname) {
+            hostname = ShellySmartmeterEmulation.getDeviceName();
+        }
+
         // Hostname kann nur MDNS_DOMAIN_LABEL_MAXLENGTH Zeichen lang werden !
-        if (!MDNS.begin(Config.DeviceName)) {
+        if (!MDNS.begin(hostname)) {
             LOGF_EP("Error setting up MDNS responder!");
             return;
         }
 
-        MDNS.addService("http", "tcp", 80);
-        MDNS.addService("amis-reader", "tcp", 80); // our rest api service (service "amis-reader" is not official)
-        MDNS.addServiceTxt("amis-reader", "tcp", "git_hash", __COMPILED_GIT_HASH__);
+        MDNS.addService(Config.DeviceName, "http", "tcp", 80);
+        // our rest api service (service "amis-reader" is not official)
+        MDNSResponder::hMDNSService hAmisService = MDNS.addService(Config.DeviceName, "amis-reader", "tcp", 80);
+        if (hAmisService) {
+            MDNS.addServiceTxt(hAmisService, "git_hash", __COMPILED_GIT_HASH__);
+        }
         /*
         There is no 'modbus' service available
         see: https://www.dns-sd.org/servicetypes.html abd RFC2782
@@ -417,6 +469,13 @@ void NetworkClass::restartMDNSIfNeeded()
         if (Config.smart_mtr) {
             MDNS.addService("modbus", "tcp", SMARTMETER_EMULATION_SERVER_PORT);
         }*/
+
+        if (ShellySmartmeterEmulation.httpApiEnabled()) {
+            LOGF_IP("Announcing Shelly emulation '%s' via MDNS (hostname is '%s.local').",
+                    ShellySmartmeterEmulation.getDeviceId(), hostname);
+            addShellyMDNSService("http");
+            addShellyMDNSService("shelly");
+        }
 
         LOG_DP("MDNS (re)started");
     }

--- a/src/ShellySmartmeterEmulation.cpp
+++ b/src/ShellySmartmeterEmulation.cpp
@@ -1,17 +1,24 @@
 #include "ShellySmartmeterEmulation.h"
+#include "config.h"
 #include "Json.h"
 #include "Log.h"
 #define LOGMODULE   LOGMODULE_SHELLY
 #include "Network.h"
-#include "unused.h"
 
 #include "proj.h"
 
+#include <ESP8266WiFi.h>
 #include <functional>
 
 typedef struct {
-    uint16_t port;
-    const char *pstr_id;
+    uint16_t port;              // Port of the "RPC over UDP" API
+    const char *pstr_id;        // Prefix of the device id, also announced as mDNS TXT record "app"
+    const char *pstr_name;      // Prefix of the device name (mDNS instance name), mixed case
+    const char *pstr_app;       // Application name as reported by "Shelly.GetDeviceInfo"
+    const char *pstr_model;     // Model name as reported by "Shelly.GetDeviceInfo" and via mDNS
+    uint8_t generation;         // Shelly device generation as reported by "Shelly.GetDeviceInfo"
+    uint8_t mdnsGeneration;     // Shelly device generation as announced via mDNS (see note below)
+    bool triphase;              // true: 3 phase device (EM.*), false: single phase device (EM1.*)
 } _devicesAvailable_t;
 
 //NOTE: be careful, index of array must match the selected dropbox value of index.html
@@ -19,24 +26,66 @@ const char ID_EM50[] PROGMEM = "shellyproem50";
 const char ID_EMG3[] PROGMEM = "shellyemg3";
 const char ID_P3EM[] PROGMEM = "shellypro3em";
 
+// The device name uses the "official" spelling, the device id is its lowercase variant
+const char NAME_EM50[] PROGMEM = "ShellyProEM50";
+const char NAME_EMG3[] PROGMEM = "ShellyEMG3";
+const char NAME_P3EM[] PROGMEM = "ShellyPro3EM";
+
+const char APP_EM50[] PROGMEM = "PROEM50";
+const char APP_EMG3[] PROGMEM = "S3EM";
+const char APP_P3EM[] PROGMEM = "Pro3EM";
+
+const char MODEL_EM50[] PROGMEM = "SPEM-002CEBEM50";
+const char MODEL_EMG3[] PROGMEM = "S3EM-002CXCEU";
+const char MODEL_P3EM[] PROGMEM = "SPEM-003CEBEU";
+
+/*
+  Firmware version we pretend to run. Some consumers check these values, so we report
+  what a real device would report (the values are the ones the "uni-meter" project uses,
+  they are known to work with a Solakon One).
+*/
+const char SHELLY_FW_ID[] PROGMEM = "20250924-062729/1.7.1-gd336f31";
+const char SHELLY_FW_VERSION[] PROGMEM = "1.7.1";
+
+/*
+  NOTE on the Pro 3EM announcing "gen=3" via mDNS although it is a gen 2 device:
+  That's what makes a Solakon One accept the emulation and it is the value the
+  "uni-meter" project ships as default too.
+  See https://github.com/sdeigm/uni-meter/issues/267
+*/
 static const _devicesAvailable_t _DEVICES[4] = {
-    { 2223, ID_EM50 },  //Shelly Pro EM-50
-    { 2222, ID_EMG3 },  //Shelly EM Gen3
-    { 2220, ID_P3EM },  //Shelly Pro 3EM (Firmware >=224)
-    { 1010, ID_P3EM }   //Shelly Pro 3EM (Firmware <224)
+    { 2223, ID_EM50, NAME_EM50, APP_EM50, MODEL_EM50, 2, 2, false },  //Shelly Pro EM-50
+    { 2222, ID_EMG3, NAME_EMG3, APP_EMG3, MODEL_EMG3, 3, 3, false },  //Shelly EM Gen3
+    { 2220, ID_P3EM, NAME_P3EM, APP_P3EM, MODEL_P3EM, 2, 3, true  },  //Shelly Pro 3EM (Firmware >=224)
+    { 1010, ID_P3EM, NAME_P3EM, APP_P3EM, MODEL_P3EM, 2, 3, true  }   //Shelly Pro 3EM (Firmware <224)
 };
+
+// Nominal grid values. The AMIS meter does not report them, but a lot of consumers
+// refuse to work with a voltage or frequency of 0.
+static constexpr float NOMINAL_VOLTAGE = 230.0f;
+static constexpr float NOMINAL_FREQUENCY = 50.0f;
 
 
 /*
-  Shelly Smartmeter Emulator für B2500 Batteriespeicher.
-  Es ist nur das RPC over UDP implementiert, da dies diese Geräte nutzen.
-  Nur notwendige Werte sind gesetzt, der Rest ist Fake, reicht aber für korrekte dyn. Einspeisebegrenzung.
+  Shelly Smartmeter Emulator.
+
+  Two APIs are provided:
+    - "RPC over UDP" (this file, see handleRequest()) for B2500 batteries (Marstek Saturn, ...)
+    - "RPC over HTTP" (see Webserver_Shelly.cpp) plus the mDNS announcement (see Network.cpp)
+      for consumers which discover and query the Shelly the way the real device does
+      (Solakon One, Hoymiles, Anker, ...)
+
+  Both use the same response data - only the transport and the amount of returned values differ.
+  Only necessary values are set, the rest is fake, but that's enough for a correct
+  dynamic feed-in limitation.
 */
 ShellySmartmeterEmulationClass::ShellySmartmeterEmulationClass()
 {
     using std::placeholders::_1;
     _udp.onPacket(std::bind(&ShellySmartmeterEmulationClass::handleRequest, this, _1));
 
+    _device.name[0] = '\0';
+    _device.id[0] = '\0';
     _currentValues.dataAreValid = false;
 }
 
@@ -48,25 +97,74 @@ bool ShellySmartmeterEmulationClass::init(unsigned selectedDeviceIndex, const ch
     }
 
     if (customDeviceIDAppendix[0]) {
-        snprintf_P(_device.id, sizeof(_device.id), PSTR("%S-%s"), _DEVICES[selectedDeviceIndex].pstr_id, customDeviceIDAppendix);
-        for (char *c = _device.id; *c; c++) {
-            *c = tolower(*c);
-        }
+        snprintf_P(_device.name, sizeof(_device.name), PSTR("%S-%s"), _DEVICES[selectedDeviceIndex].pstr_name, customDeviceIDAppendix);
     } else {
-        snprintf_P(_device.id, sizeof(_device.id), PSTR("%S-%x"), _DEVICES[selectedDeviceIndex].pstr_id, ESP.getChipId());
+        // A real Shelly uses its mac address - do the same, some consumers are picky
+        snprintf_P(_device.name, sizeof(_device.name), PSTR("%S-%s"), _DEVICES[selectedDeviceIndex].pstr_name, getMacAddress().c_str());
+    }
+    // The id is the lowercase variant of the name (that's how a real Shelly does it too)
+    strlcpy(_device.id, _device.name, sizeof(_device.id));
+    for (char *c = _device.id; *c; c++) {
+        *c = tolower(*c);
     }
     _device.port = _DEVICES[selectedDeviceIndex].port;
+    _deviceIndex = selectedDeviceIndex;
     _offset = offset;
 
     return true;
 }
 
+const __FlashStringHelper *ShellySmartmeterEmulationClass::getApp() const
+{
+    return FPSTR(_DEVICES[_deviceIndex].pstr_app);
+}
+
+const __FlashStringHelper *ShellySmartmeterEmulationClass::getMdnsApp() const
+{
+    return FPSTR(_DEVICES[_deviceIndex].pstr_id);
+}
+
+const __FlashStringHelper *ShellySmartmeterEmulationClass::getModel() const
+{
+    return FPSTR(_DEVICES[_deviceIndex].pstr_model);
+}
+
+unsigned ShellySmartmeterEmulationClass::getGeneration() const
+{
+    return _DEVICES[_deviceIndex].generation;
+}
+
+unsigned ShellySmartmeterEmulationClass::getMdnsGeneration() const
+{
+    return _DEVICES[_deviceIndex].mdnsGeneration;
+}
+
+bool ShellySmartmeterEmulationClass::isTriphase() const
+{
+    return _DEVICES[_deviceIndex].triphase;
+}
+
+const __FlashStringHelper *ShellySmartmeterEmulationClass::getFirmwareId()
+{
+    return FPSTR(SHELLY_FW_ID);
+}
+
+const __FlashStringHelper *ShellySmartmeterEmulationClass::getFirmwareVersion()
+{
+    return FPSTR(SHELLY_FW_VERSION);
+}
+
+String ShellySmartmeterEmulationClass::getMacAddress()
+{
+    String mac = WiFi.macAddress();
+    mac.replace(":", "");
+    mac.toUpperCase();
+    return mac;
+}
+
 void ShellySmartmeterEmulationClass::setCurrentValues(bool dataAreValid, uint32_t v1_7_0, uint32_t v2_7_0, uint32_t v1_8_0, uint32_t v2_8_0)
 {
-    UNUSED_ARG(v1_8_0);
-    UNUSED_ARG(v2_8_0);
-
-    if (!_enabled) {
+    if (!_enabled && !_httpApiEnabled) {
         return; // Don't waste time if there is nothing to do
     }
     _currentValues.dataAreValid = dataAreValid;
@@ -75,6 +173,8 @@ void ShellySmartmeterEmulationClass::setCurrentValues(bool dataAreValid, uint32_
     }
 
     _currentValues.saldo = (int32_t)v1_7_0 - (int32_t)v2_7_0; //directly calculate saldo (otherwise we need some mutex around)
+    _currentValues.v1_8_0 = v1_8_0;
+    _currentValues.v2_8_0 = v2_8_0;
 }
 
 bool ShellySmartmeterEmulationClass::setEnabled(bool enabled)
@@ -87,7 +187,232 @@ bool ShellySmartmeterEmulationClass::setEnabled(bool enabled)
     return _enabled;
 }
 
+
 /*
+    Builds the "result" object of a RPC response.
+
+    'minimalResponse' is used by the UDP API: the B2500 batteries are picky and the
+    minimal response is a proven one - so don't extend it there.
+*/
+bool ShellySmartmeterEmulationClass::buildRpcResult(const char *method, JsonObject result, bool minimalResponse)
+{
+    if (!strcmp_P(method, PSTR("EM.GetStatus"))) {
+        if (!_currentValues.dataAreValid) {
+            return false;
+        }
+        buildEmGetStatus(result, minimalResponse);
+        return true;
+    }
+    if (!strcmp_P(method, PSTR("EM1.GetStatus"))) {
+        if (!_currentValues.dataAreValid) {
+            return false;
+        }
+        buildEm1GetStatus(result, minimalResponse);
+        return true;
+    }
+    if (minimalResponse) {
+        // Everything below is only answered on the HTTP API
+        return false;
+    }
+    if (!strcmp_P(method, PSTR("EMData.GetStatus"))) {
+        if (!_currentValues.dataAreValid) {
+            return false;
+        }
+        buildEmDataGetStatus(result);
+        return true;
+    }
+    if (!strcmp_P(method, PSTR("EM1Data.GetStatus"))) {
+        if (!_currentValues.dataAreValid) {
+            return false;
+        }
+        buildEm1DataGetStatus(result);
+        return true;
+    }
+    if (!strcmp_P(method, PSTR("EM.GetConfig")) || !strcmp_P(method, PSTR("EM1.GetConfig"))) {
+        buildEmGetConfig(result);
+        return true;
+    }
+    if (!strcmp_P(method, PSTR("Shelly.GetDeviceInfo"))) {
+        buildDeviceInfo(result);
+        return true;
+    }
+    if (!strcmp_P(method, PSTR("Shelly.ListMethods"))) {
+        buildListMethods(result);
+        return true;
+    }
+
+    return false;
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EM#emgetstatus-example
+
+    The saldo is reported on phase A only - splitting it up over all three phases would
+    be a fake which nobody asked for (see discussion in issue #36).
+*/
+void ShellySmartmeterEmulationClass::buildEmGetStatus(JsonObject result, bool minimalResponse)
+{
+    int32_t saldoW = saldo();
+
+    if (minimalResponse) {
+        //the B2500 is VEEEERY picky... needs "float" formatted value with a dot
+        String saldoMinimal = String(saldoW) + ".0";
+        result["a_act_power"] = serialized(saldoMinimal);
+        result["b_act_power"] = serialized("0.0");
+        result["c_act_power"] = serialized("0.0");
+        result["total_act_power"] = serialized(saldoMinimal);
+        return;
+    }
+
+    String saldoStr = String(saldoW) + ".00";
+
+    String current = String(saldoW / NOMINAL_VOLTAGE, 2);
+    String apparent = String(saldoW < 0 ? -(float)saldoW : (float)saldoW, 2);
+    String voltage = String(NOMINAL_VOLTAGE, 2);
+    String frequency = String(NOMINAL_FREQUENCY, 2);
+
+    result["id"] = 0;
+
+    result["a_current"] = serialized(current);
+    result["a_voltage"] = serialized(voltage);
+    result["a_act_power"] = serialized(saldoStr);
+    result["a_aprt_power"] = serialized(apparent);
+    result["a_pf"] = serialized("1.00");
+    result["a_freq"] = serialized(frequency);
+
+    result["b_current"] = serialized("0.00");
+    result["b_voltage"] = serialized(voltage);
+    result["b_act_power"] = serialized("0.00");
+    result["b_aprt_power"] = serialized("0.00");
+    result["b_pf"] = serialized("1.00");
+    result["b_freq"] = serialized(frequency);
+
+    result["c_current"] = serialized("0.00");
+    result["c_voltage"] = serialized(voltage);
+    result["c_act_power"] = serialized("0.00");
+    result["c_aprt_power"] = serialized("0.00");
+    result["c_pf"] = serialized("1.00");
+    result["c_freq"] = serialized(frequency);
+
+    result["n_current"] = nullptr;
+    result["total_current"] = serialized(current);
+    result["total_act_power"] = serialized(saldoStr);
+    result["total_aprt_power"] = serialized(apparent);
+    result.createNestedArray("user_calibrated_phase");
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EM1#em1getstatus-example
+*/
+void ShellySmartmeterEmulationClass::buildEm1GetStatus(JsonObject result, bool minimalResponse)
+{
+    int32_t saldoW = saldo();
+
+    if (minimalResponse) {
+        //the B2500 is VEEEERY picky... needs "float" formatted value with a dot
+        result["act_power"] = serialized(String(saldoW) + ".0");
+        return;
+    }
+
+    String saldoStr = String(saldoW) + ".00";
+    String current = String(saldoW / NOMINAL_VOLTAGE, 2);
+
+    result["id"] = 0;
+    result["current"] = serialized(current);
+    result["voltage"] = serialized(String(NOMINAL_VOLTAGE, 2));
+    result["act_power"] = serialized(saldoStr);
+    result["aprt_power"] = serialized(String(saldoW < 0 ? -(float)saldoW : (float)saldoW, 2));
+    result["pf"] = serialized("1.00");
+    result["freq"] = serialized(String(NOMINAL_FREQUENCY, 2));
+    result["calibration"] = F("factory");
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EMData#emdatagetstatus-example
+
+    Energy counters are reported in Wh - that's exactly what the meter delivers in 1.8.0/2.8.0.
+*/
+void ShellySmartmeterEmulationClass::buildEmDataGetStatus(JsonObject result)
+{
+    String consumed = String(_currentValues.v1_8_0) + ".00";
+    String returned = String(_currentValues.v2_8_0) + ".00";
+
+    result["id"] = 0;
+    result["a_total_act_energy"] = serialized(consumed);
+    result["a_total_act_ret_energy"] = serialized(returned);
+    result["b_total_act_energy"] = serialized("0.00");
+    result["b_total_act_ret_energy"] = serialized("0.00");
+    result["c_total_act_energy"] = serialized("0.00");
+    result["c_total_act_ret_energy"] = serialized("0.00");
+    result["total_act"] = serialized(consumed);
+    result["total_act_ret"] = serialized(returned);
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EM1Data#em1datagetstatus-example
+*/
+void ShellySmartmeterEmulationClass::buildEm1DataGetStatus(JsonObject result)
+{
+    result["id"] = 0;
+    result["total_act_energy"] = serialized(String(_currentValues.v1_8_0) + ".00");
+    result["total_act_ret_energy"] = serialized(String(_currentValues.v2_8_0) + ".00");
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EM#emgetconfig-example
+*/
+void ShellySmartmeterEmulationClass::buildEmGetConfig(JsonObject result)
+{
+    result["id"] = 0;
+    result["name"] = nullptr;
+    result["blink_mode_selector"] = F("active_energy");
+    result["phase_selector"] = F("a");
+    result["monitor_phase_sequence"] = false;
+    result["ct_type"] = F("120A");
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Shelly#shellygetdeviceinfo-example
+*/
+void ShellySmartmeterEmulationClass::buildDeviceInfo(JsonObject result)
+{
+    result["name"] = Config.DeviceName;
+    result["id"] = _device.name;
+    result["mac"] = getMacAddress();
+    result["slot"] = 1;
+    result["model"] = getModel();
+    result["gen"] = getGeneration();
+    result["fw_id"] = getFirmwareId();
+    result["ver"] = getFirmwareVersion();
+    result["app"] = getApp();
+    result["auth_en"] = false;
+    result["auth_domain"] = nullptr;
+    result["profile"] = isTriphase() ? F("triphase") : F("monophase");
+}
+
+/*
+    https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Shelly#shellylistmethods-example
+*/
+void ShellySmartmeterEmulationClass::buildListMethods(JsonObject result)
+{
+    JsonArray methods = result.createNestedArray("methods");
+    if (isTriphase()) {
+        methods.add(F("EM.GetConfig"));
+        methods.add(F("EM.GetStatus"));
+        methods.add(F("EMData.GetStatus"));
+    } else {
+        methods.add(F("EM1.GetConfig"));
+        methods.add(F("EM1.GetStatus"));
+        methods.add(F("EM1Data.GetStatus"));
+    }
+    methods.add(F("Shelly.GetDeviceInfo"));
+    methods.add(F("Shelly.ListMethods"));
+}
+
+
+/*
+    "RPC over UDP"
+
     request looks like:
         {"id":1,"method":"EM.GetStatus","params":{"id":0}}
         {"id":1,"method":"EM1.GetStatus","params":{"id":0}}
@@ -139,16 +464,8 @@ void ShellySmartmeterEmulationClass::handleRequest(AsyncUDPPacket udpPacket) {
     responseJson["dst"] = "unknown";
     JsonObject result = responseJson.createNestedObject("result");
 
-    //the B2500 is VEEEERY picky... needs "float" formatted value with a dot
-    String saldo = String(_currentValues.saldo + _offset) + ".0";
-    if (!strcmp(method, "EM.GetStatus")) {
-        result["a_act_power"] = serialized(saldo);
-        result["b_act_power"] = serialized("0.0");
-        result["c_act_power"] = serialized("0.0");
-        result["total_act_power"] = serialized(saldo);
-    } else if (!strcmp(method, "EM1.GetStatus")) {
-        result["act_power"] = serialized(saldo);
-    } else {
+    // Keep the UDP responses minimal - that's what the B2500 batteries expect
+    if (!buildRpcResult(method, result, true)) {
         LOGF_WP("Unknown method: %s", method);
         return;
     }
@@ -188,6 +505,30 @@ void ShellySmartmeterEmulationClass::disable(void)
         LOG_IP("disabled");
     }
     _enabled = false;
+    disableHttpApi();
+}
+
+bool ShellySmartmeterEmulationClass::enableHttpApi(void)
+{
+    if (_httpApiEnabled) {
+        return true;
+    }
+    if (Network.inAPMode() || !isInitialized()) {
+        return false;
+    }
+
+    LOGF_IP("Starting HTTP API, id '%s' offset %d W", _device.id, _offset);
+    _httpApiEnabled = true;
+
+    return _httpApiEnabled;
+}
+
+void ShellySmartmeterEmulationClass::disableHttpApi(void)
+{
+    if (_httpApiEnabled) {
+        LOG_IP("HTTP API disabled");
+    }
+    _httpApiEnabled = false;
 }
 
 

--- a/src/Webserver.cpp
+++ b/src/Webserver.cpp
@@ -123,6 +123,7 @@ void WebserverClass::init()
     // Initilisieren der einzelnen Handler für diverse Unterverzeichnisse
     _websrvLogin.init(_server);
     _websrvRest.init(_server);
+    _websrvShelly.init(_server);
     _websrvUpdate.init(_server);
 
     // Initilisieren der Websocket Handler

--- a/src/Webserver_Shelly.cpp
+++ b/src/Webserver_Shelly.cpp
@@ -1,0 +1,222 @@
+/*
+    Shelly emulation: "RPC over HTTP"
+
+    Serves the endpoints a real Shelly (Gen2+) provides, so consumers which talk to a
+    Shelly the way the original device does can use the AMIS reader as their smartmeter
+    (Solakon One, Hoymiles, Anker, ...).
+
+        GET  /shelly                     -> device information (also used by Gen1 clients)
+        GET  /rpc                        -> list of the supported methods
+        GET  /rpc/<Method>[?id=0]        -> the "result" object of <Method>
+        POST /rpc  {"id":1,"method":...} -> full json rpc response
+
+    Announcing the device via mDNS is done in Network.cpp, the responses itself are built
+    by ShellySmartmeterEmulationClass - the very same ones the UDP API uses.
+
+    NOTE: These endpoints are intentionally not protected by the webserver credentials.
+          A consumer can not authenticate itself and a real Shelly is unprotected by default too.
+*/
+
+#include "Webserver_Shelly.h"
+
+#include "Json.h"
+#include "Log.h"
+#define LOGMODULE LOGMODULE_SHELLY
+#include "ShellySmartmeterEmulation.h"
+
+// Enough for the biggest supported result plus the surrounding json rpc response
+#define SHELLY_RPC_RESPONSE_JSON_CAPACITY   (SHELLY_RPC_RESULT_JSON_CAPACITY + JSON_OBJECT_SIZE(4) + 64)
+
+// Requests bigger than that are surely not a json rpc request of a smartmeter consumer
+#define SHELLY_RPC_MAX_REQUEST_SIZE         512
+
+// Size of the response buffers. The biggest response ("EM.GetStatus") is 468 bytes,
+// the json rpc envelope around it adds ~80 more. Keeping these tight matters: a
+// consumer polls us about once a second and the default of 1460 bytes would just
+// stress the heap.
+#define SHELLY_RPC_RESULT_STREAM_SIZE       512
+#define SHELLY_RPC_RESPONSE_STREAM_SIZE     640
+#define SHELLY_RPC_ERROR_STREAM_SIZE        128
+
+
+void WebserverShellyClass::init(AsyncWebServer& server)
+{
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    using std::placeholders::_3;
+    using std::placeholders::_4;
+    using std::placeholders::_5;
+
+    server.on("/shelly", HTTP_GET, std::bind(&WebserverShellyClass::onShellyRequest, this, _1));
+
+    // A handler registered on "/rpc" is called for "/rpc" and for everything below "/rpc/"
+    server.on("/rpc", HTTP_GET, std::bind(&WebserverShellyClass::onRpcGetRequest, this, _1));
+    server.on("/rpc", HTTP_POST,
+              std::bind(&WebserverShellyClass::onRpcPostRequest, this, _1),
+              nullptr,
+              std::bind(&WebserverShellyClass::onRpcPostBody, this, _1, _2, _3, _4, _5));
+}
+
+/*
+    GET /shelly
+
+    Returns the device information without the json rpc envelope.
+*/
+void WebserverShellyClass::onShellyRequest(AsyncWebServerRequest* request)
+{
+    sendRpcResult(request, "Shelly.GetDeviceInfo");
+}
+
+/*
+    GET /rpc/<Method>
+
+    A real Shelly answers a HTTP GET with the plain "result" object (no json rpc envelope).
+    "GET /rpc" (without a method) returns the list of the available methods.
+*/
+void WebserverShellyClass::onRpcGetRequest(AsyncWebServerRequest* request)
+{
+    const String &url = request->url();
+
+    // strlen("/rpc/") == 5
+    if (url.length() <= 5) {
+        sendRpcResult(request, "Shelly.ListMethods");
+        return;
+    }
+
+    sendRpcResult(request, url.c_str() + 5);
+}
+
+/*
+    POST /rpc  with a json rpc request as body, eg {"id":1,"method":"EM.GetStatus","params":{"id":0}}
+
+    The body has been collected by onRpcPostBody() into request->_tempObject.
+*/
+void WebserverShellyClass::onRpcPostRequest(AsyncWebServerRequest* request)
+{
+    if (!ShellySmartmeterEmulation.httpApiEnabled()) {
+        request->send(404);
+        return;
+    }
+    if (!request->_tempObject) {
+        sendRpcError(request, 400, nullptr);
+        return;
+    }
+
+    StaticJsonDocument<JSON_OBJECT_SIZE(8) + 128> requestJson;
+    DeserializationError error = deserializeJson(requestJson, (const char*) request->_tempObject);
+    if (error) {
+        LOGF_EP("Failed to parse json. Error '%s'", error.c_str());
+        sendRpcError(request, 400, nullptr);
+        return;
+    }
+    if (!requestJson["method"].is<const char*>()) {
+        sendRpcError(request, 400, nullptr);
+        return;
+    }
+    const char *method = requestJson["method"];
+
+    DynamicJsonDocument responseJson(SHELLY_RPC_RESPONSE_JSON_CAPACITY);
+    if (!responseJson.capacity()) {
+        LOG_EP("Json rpc response: Out of memory");
+        request->send(500);
+        return;
+    }
+    responseJson["id"] = requestJson["id"] | 1;
+    responseJson["src"] = ShellySmartmeterEmulation.getDeviceId();
+    if (requestJson["src"].is<const char*>()) {
+        responseJson["dst"] = requestJson["src"];
+    }
+    JsonObject result = responseJson.createNestedObject("result");
+
+    if (!ShellySmartmeterEmulation.buildRpcResult(method, result)) {
+        // No valid meter data yet? Then the method is fine, we just can't answer it (yet)
+        sendRpcError(request, ShellySmartmeterEmulation.hasValidData() ? 404 : 503, method);
+        return;
+    }
+
+    AsyncResponseStream *response = request->beginResponseStream(F("application/json"), SHELLY_RPC_RESPONSE_STREAM_SIZE);
+    SERIALIZE_JSON_LOG(responseJson, *response);
+    request->send(response);
+}
+
+void WebserverShellyClass::onRpcPostBody(AsyncWebServerRequest* request, uint8_t *data, size_t len, size_t index, size_t total)
+{
+    if (!ShellySmartmeterEmulation.httpApiEnabled()) {
+        return;
+    }
+    if (total == 0 || total > SHELLY_RPC_MAX_REQUEST_SIZE) {
+        LOGF_EP("Invalid rpc request size %u", total);
+        return;
+    }
+
+    if (index == 0) {
+        // Freed by the destructor of AsyncWebServerRequest. One extra byte so the
+        // buffer is always '\0' terminated for the json parser.
+        request->_tempObject = calloc(total + 1, 1);
+        if (!request->_tempObject) {
+            LOG_EP("Out of memory receiving rpc request");
+            return;
+        }
+    }
+    if (request->_tempObject && (index + len) <= total) {
+        memcpy((uint8_t*) request->_tempObject + index, data, len);
+    }
+}
+
+/*
+    Builds the "result" object of 'method' and sends it as response.
+*/
+bool WebserverShellyClass::sendRpcResult(AsyncWebServerRequest* request, const char *method)
+{
+    if (!ShellySmartmeterEmulation.httpApiEnabled()) {
+        request->send(404);
+        return false;
+    }
+
+    DynamicJsonDocument resultJson(SHELLY_RPC_RESULT_JSON_CAPACITY);
+    if (!resultJson.capacity()) {
+        LOG_EP("Json rpc result: Out of memory");
+        request->send(500);
+        return false;
+    }
+
+    JsonObject result = resultJson.to<JsonObject>();
+    if (!ShellySmartmeterEmulation.buildRpcResult(method, result)) {
+        // No valid meter data yet? Then the method is fine, we just can't answer it (yet)
+        sendRpcError(request, ShellySmartmeterEmulation.hasValidData() ? 404 : 503, method);
+        return false;
+    }
+
+    LOGF_DP("Serving '%s' to " PRsIP, method, PRIPVal(request->client()->remoteIP()));
+
+    AsyncResponseStream *response = request->beginResponseStream(F("application/json"), SHELLY_RPC_RESULT_STREAM_SIZE);
+    SERIALIZE_JSON_LOG(resultJson, *response);
+    request->send(response);
+    return true;
+}
+
+/*
+    Error response in the format a real Shelly uses, eg
+        {"code":404,"message":"No handler for EM.GetStatus"}
+*/
+void WebserverShellyClass::sendRpcError(AsyncWebServerRequest* request, int code, const char *method)
+{
+    StaticJsonDocument<JSON_OBJECT_SIZE(2) + 96> errorJson;
+    errorJson["code"] = code;
+    if (code == 503) {
+        LOGF_WP("No valid meter data available for method: %s", method);
+        errorJson["message"] = F("No valid meter data available");
+    } else if (method) {
+        LOGF_WP("Unknown method: %s", method);
+        errorJson["message"] = String(F("No handler for ")) + method;
+    } else {
+        errorJson["message"] = F("Invalid request");
+    }
+
+    AsyncResponseStream *response = request->beginResponseStream(F("application/json"), SHELLY_RPC_ERROR_STREAM_SIZE);
+    response->setCode(code);
+    SERIALIZE_JSON_LOG(errorJson, *response);
+    request->send(response);
+}
+
+/* vim:set ts=4 et: */

--- a/src/Webserver_ws_Data.cpp
+++ b/src/Webserver_ws_Data.cpp
@@ -271,7 +271,7 @@ void WebserverWsDataClass::wsClientRequest(AsyncWebSocketClient *client, char* r
         "pingrestart_max": "5",
         "channel": "0"
     }
-    { // 32 Objects
+    { // 34 Objects
         "command": "/config_general",
         "devicetype": "AMIS-Reader",
         "devicename": "Amis-1",
@@ -299,6 +299,8 @@ void WebserverWsDataClass::wsClientRequest(AsyncWebSocketClient *client, char* r
         "switch_intervall": "60",
         "reboot0": true,
         "shelly_smart_mtr_udp": false,
+        "shelly_smart_mtr_http": false,
+        "shelly_smart_mtr_http_hostname": false,
         "shelly_smart_mtr_udp_device": "shellypro3em",
         "shelly_smart_mtr_udp_offset": "0",
         "shelly_smart_mtr_udp_hardwareID": "",
@@ -323,7 +325,7 @@ void WebserverWsDataClass::wsClientRequest(AsyncWebSocketClient *client, char* r
     */
 
     // add space for 5 "additional" objects and some extra bytes
-    DynamicJsonDocument root(JSON_OBJECT_SIZE(32) + JSON_OBJECT_SIZE(5) + 32); // ~624 bytes
+    DynamicJsonDocument root(JSON_OBJECT_SIZE(34) + JSON_OBJECT_SIZE(5) + 32); // ~656 bytes
 
     // Do not change 'requestData' ... but then we need more memory!
     // error = deserializeJson(root, (const char*) requestData, requestLength);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -165,6 +165,8 @@ void ConfigClass::loadConfigGeneral()
 
     smart_mtr = json[F("smart_mtr")].as<bool>();
     shelly_smart_mtr_udp = json[F("shelly_smart_mtr_udp")].as<bool>();
+    shelly_smart_mtr_http = json[F("shelly_smart_mtr_http")].as<bool>();
+    shelly_smart_mtr_http_hostname = json[F("shelly_smart_mtr_http_hostname")].as<bool>();
     shelly_smart_mtr_udp_device_index = json[F("shelly_smart_mtr_udp_device_index")].as<unsigned>();
     shelly_smart_mtr_udp_offset = json[F("shelly_smart_mtr_udp_offset")].as<int>();
 
@@ -228,16 +230,22 @@ void ConfigClass::applySettingsConfigGeneral()
 
     Webserver.reloadCredentials();
 
-    // Config.Devicename könnte geändert worden sein! ==> ev MDNS neu starten!
-    Network.restartMDNSIfNeeded();
-
     // Shelly
+    // NOTE: must be done before restarting MDNS - the announced services depend on it
     ShellySmartmeterEmulation.disable();
-    if (Config.shelly_smart_mtr_udp &&
+    if ((Config.shelly_smart_mtr_udp || Config.shelly_smart_mtr_http) &&
         ShellySmartmeterEmulation.init(Config.shelly_smart_mtr_udp_device_index, Config.shelly_smart_mtr_udp_hardware_id_appendix, Config.shelly_smart_mtr_udp_offset))
     {
-        ShellySmartmeterEmulation.enable();
+        if (Config.shelly_smart_mtr_udp) {
+            ShellySmartmeterEmulation.enable();
+        }
+        if (Config.shelly_smart_mtr_http) {
+            ShellySmartmeterEmulation.enableHttpApi();
+        }
     }
+
+    // Config.Devicename könnte geändert worden sein! ==> ev MDNS neu starten!
+    Network.restartMDNSIfNeeded();
 
     // TODO(anyone): Apply more settings but we must first check setup() as there are prior some MODULE.init() calls
 #if 0

--- a/src/local/DefaultConfigurations.cpp.example
+++ b/src/local/DefaultConfigurations.cpp.example
@@ -49,6 +49,8 @@ const char *defaultConfigGerneralJson = R"(
     "rest_neg": false,
     "smart_mtr": false,
     "shelly_smart_mtr_udp": false,
+    "shelly_smart_mtr_http": false,
+    "shelly_smart_mtr_http_hostname": false,
     "shelly_smart_mtr_udp_device_index": 0,
     "shelly_smart_mtr_udp_offset": 0,
     "shelly_smart_mtr_udp_hardware_id_appendix": "",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,10 +156,17 @@ void setup() {
     }
 
     // Shelly Smart Meter Emulator
-    if (Config.shelly_smart_mtr_udp &&
+    if ((Config.shelly_smart_mtr_udp || Config.shelly_smart_mtr_http) &&
         ShellySmartmeterEmulation.init(Config.shelly_smart_mtr_udp_device_index, Config.shelly_smart_mtr_udp_hardware_id_appendix, Config.shelly_smart_mtr_udp_offset))
     {
-        ShellySmartmeterEmulation.enable();
+        if (Config.shelly_smart_mtr_udp) {
+            ShellySmartmeterEmulation.enable();
+        }
+        if (Config.shelly_smart_mtr_http) {
+            // The endpoints are served by our webserver, the mDNS announcement is done
+            // by Network.restartMDNSIfNeeded() - which is called once we are connected.
+            ShellySmartmeterEmulation.enableHttpApi();
+        }
     }
 
 


### PR DESCRIPTION
# Shelly Emulation: RPC over HTTP und mDNS Ankündigung

Schließt #36.

## Warum

Bisher war nur "RPC over UDP" implementiert (PR #42), womit Balkonspeicher vom Typ B2500 (Marstek Saturn) bedient werden. Speicher wie der **Solakon One**, Hoymiles oder Anker arbeiten anders: Sie suchen den Shelly per mDNS im Netzwerk und fragen ihn danach per HTTP ab. Wie @Kupferfox in #36 geschrieben hat, fehlte dafür "ein mDNS Endpoint + sehr ähnliche JSON Kommunikation aber per TCP".

Genau das macht dieser PR.

## Was dazukommt

Der bestehende Webserver beantwortet zusätzlich:

| Endpoint | Antwort |
|---|---|
| `GET /shelly` | Geräteinformation |
| `GET /rpc` | Liste der unterstützten Methoden |
| `GET /rpc/<Methode>[?id=0]` | das nackte `result` Objekt, so wie es ein echter Shelly bei HTTP GET liefert |
| `POST /rpc` | vollständige json rpc Antwort mit `id`/`src`/`dst` |

Methoden: `EM.GetStatus`, `EMData.GetStatus`, `EM.GetConfig`, `Shelly.GetDeviceInfo`, `Shelly.ListMethods`. Bei den einphasigen Geräten (Pro EM-50, EM Gen3) entsprechend die `EM1.*` Varianten.

Dazu die Ankündigung per mDNS als `_http._tcp` und `_shelly._tcp` mit dem Instanznamen des Shelly und den TXT Records, die die Speicher auswerten. Der mDNS Responder wird dafür auch gestartet, wenn der Benutzer mDNS in den WLAN Einstellungen nicht aktiviert hat — ohne ihn gäbe es keine Discovery.

Die Endpoints sind bewusst **nicht** durch die Webserver Zugangsdaten geschützt. Ein Speicher kann sich nicht anmelden, und ein echter Shelly ist per Default auch offen. Das sollte man wissen: Wer die Emulation aktiviert, gibt die aktuellen Leistungswerte im LAN frei, auch wenn die Oberfläche ein Passwort hat.

## Zum Refactoring

`ShellySmartmeterEmulationClass` baut die Antworten jetzt für beide Transporte an einer Stelle (`buildRpcResult()`). @Kupferfox hatte in #36 richtig bemerkt, dass die Daten ohnehin immer dieselben sind und nur der Endpoint ein anderer ist.

Die **UDP Antworten bleiben dabei byte-identisch** zu vorher. Dafür gibt es einen Parameter `minimalResponse`, den nur der UDP Pfad setzt. Der Kommentar im bestehenden Code ("the B2500 is VEEEERY picky") schien mir Grund genug, an einer funktionierenden Implementierung nichts zu ändern. Einziger Unterschied ist das `src` Feld, siehe unten.

Den Saldo künstlich auf drei Phasen aufzuteilen habe ich nicht gemacht — das war in #36 diskutiert und von @Kupferfox und mir verworfen worden. Phase A trägt den Saldo, B und C sind 0.

## Details, die sich beim Testen als notwendig erwiesen haben

Diese Punkte kosten sonst viel Zeit, deshalb hier gesammelt:

- **Der mDNS Instanzname braucht die gemischte Schreibweise** `ShellyPro3EM-<MAC>`, die Geräte sind da case sensitiv. Der TXT Record `id` ist dagegen kleingeschrieben. Diese Inkonsistenz haben Originalgerät und uni-meter genauso.
- **Der TXT Record `mac` wird mit Doppelpunkten angekündigt** (`DE:8E:DB:B0:3B:A9`), in `Shelly.GetDeviceInfo` dagegen ohne.
- **Der Pro 3EM meldet per mDNS `gen=3`**, in `Shelly.GetDeviceInfo` aber korrekt `gen=2`. Auch das ist inkonsistent, aber es ist die Kombination, die funktioniert — siehe sdeigm/uni-meter#267.
- **Die Geräte ID basiert jetzt auf der vollen MAC Adresse** statt auf `ESP.getChipId()`, so wie beim Originalgerät. Das ändert für bestehende UDP Nutzer das `src` Feld der Antwort. Sowohl uni-meter als auch Energy2Shelly_ESP machen es so, und beide laufen mit B2500 Speichern, das Risiko halte ich für klein. Wer will, kann über das bestehende Feld "Shelly Hardware ID" weiterhin etwas Eigenes setzen.
- Zahlenformat der HTTP Antworten sind zwei Nachkommastellen, wie beim Originalgerät.

Die Werte für `fw_id`, `ver`, `model` und `arch` sind die eines echten Pro 3EM. `arch` meldet `esp32`, obwohl wir ein esp8266 sind — emuliert wird das Original, nicht wir selbst.

## Konfiguration

Zwei neue Schlüssel in `/config_general`:

- `shelly_smart_mtr_http` — schaltet HTTP Emulation und mDNS Ankündigung ein. Kann gemeinsam mit der UDP Emulation aktiv sein, die Auswahl der Shelly Version gilt für beide.
- `shelly_smart_mtr_http_hostname` — übernimmt den Shelly Namen als mDNS Hostnamen, für Geräte die `<Shelly-Name>.local` direkt auflösen statt dem SRV Eintrag zu folgen. **Standardmäßig aus.** Ein Solakon One braucht das nicht, und der ESP8266 kann nur einen einzigen mDNS Hostnamen führen — `<Gerätename>.local` wäre dann nicht mehr auflösbar.

## Getestet

An einem AMIS Leser (1.6.2) mit einem **Solakon One**: Der Speicher findet den Leser als Shelly und fragt die Daten ab.

Dazu am Gerät:

- Alle Endpoints gegen die Zählerwerte abgeglichen, inklusive Zählwerke in `EMData.GetStatus`
- mDNS Ankündigung mit `avahi-browse` gegen eine laufende uni-meter Instanz verglichen, TXT Records stimmen überein
- Lasttest 240 Anfragen (150× sekündlich, 60× Burst, 30× POST): 0 Fehler, kein abgeschnittenes JSON
- Heap davor 18.320 frei / 8 % fragmentiert, danach 21.768 / 8 % — kein Leck erkennbar
- UDP Emulation gegengeprüft, Antwortformat unverändert
- Beide Schalterstellungen der Hostnamen-Option verifiziert
- Modbus Emulation parallel betrieben, Register stimmen mit dem Zähler überein

Die json Dokumentgrößen habe ich zusätzlich mit einem 32-Bit Hosttest gegen dieselbe ArduinoJson Version geprüft, damit bei Extremwerten nichts still überläuft. Worst Case `EM.GetStatus` 505 von 688 Bytes, UDP Minimalantwort 189 von 260.

Ressourcen: RAM 50,2 % → 51,0 %, Flash 57,2 % → 58,6 %. Die Antwortpuffer sind bewusst auf 512 statt der voreingestellten 1460 Bytes gesetzt, weil ein Speicher etwa sekündlich pollt.

Baut sauber für `esp12e` und `esp12e_debug`, keine neuen Warnungen.

## Was nicht getestet ist

- **Anker und Hoymiles.** @ScheraAtGithub und @steinmar2 hatten sich in #36 als Tester angeboten.
- Die `EM1.*` Varianten (Pro EM-50, EM Gen3) sind implementiert, aber mangels Gerät nur gegen die API Dokumentation geprüft.
- Langzeitstabilität. Der Lasttest lief Minuten, nicht Tage.

## Nicht Teil dieses PR

Zwei Sachen, die mir beim Testen aufgefallen sind und die eigene Issues verdienen:

1. Die **Modbus Emulation stürzt ab**, wenn ein Client pro Abfrage eine neue TCP Verbindung öffnet (`Exception 29`, StoreProhibited auf Adresse 0, nach etwa 36 Verbindungen). Reproduzierbar ohne jede Beteiligung der Shelly Emulation. Bei persistenter Verbindung, so wie ein Fronius arbeitet, passiert nichts.
2. **`smart_mtr` wirkt erst beim Booten**, weil der entsprechende Zweig in `applySettingsConfigGeneral()` in einem `#if 0` liegt. In der Oberfläche sieht es so aus, als hätte die Einstellung sofort gegriffen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
